### PR TITLE
Crashing bug in replacePlaceholdersAndPrintStringFromBlock:

### DIFF
--- a/GBCli/src/GBOptionsHelper.m
+++ b/GBCli/src/GBOptionsHelper.m
@@ -325,8 +325,10 @@
 	}
 	NSString *string = block();
 	string = [string stringByReplacingOccurrencesOfString:@"%APPNAME" withString:self.applicationNameFromBlockOrDefault];
-	string = [string stringByReplacingOccurrencesOfString:@"%APPVERSION" withString:self.applicationVersionFromBlockOrNil];
-	string = [string stringByReplacingOccurrencesOfString:@"%APPBUILD" withString:self.applicationBuildFromBlockOrNil];
+  if ( self.applicationVersionFromBlockOrNil )
+    string = [string stringByReplacingOccurrencesOfString:@"%APPVERSION" withString:self.applicationVersionFromBlockOrNil];
+  if ( self.applicationBuildFromBlockOrNil )
+    string = [string stringByReplacingOccurrencesOfString:@"%APPBUILD" withString:self.applicationBuildFromBlockOrNil];
 	printf("%s\n", string.UTF8String);
 }
 


### PR DESCRIPTION
The method stringByReplacingOccurrencesOfString:withString: throws an
exception if the withString: parameter is nil!  Added checks to make
sure we have a value before trying to do the replacement.

A simple example to test this is to run the following code snippet as a terminal app:
    NSString\* hello = @"Hello, World!";
    hello = [hello stringByReplacingOccurrencesOfString:@"World" withString:nil];

You'll get an exception because you've passed in a nil argument in the withString: parameter.
