### PR TITLE
Fix format for GBParseFlagMissingValue error

### DIFF
--- a/GBCli/src/GBCommandLineParser.m
+++ b/GBCli/src/GBCommandLineParser.m
@@ -141,7 +141,7 @@ static NSString * const GBCommandLineNotAnOptionKey = @"not-an-option"; // this 
 				gbfprintln(stderr, @"Unknown command line option %@, try --help!", argument);
 				break;
 			case GBParseFlagMissingValue:
-				gbfprintln(stderr, @"Missing value for command line option %s, try --help!", argument);
+				gbfprintln(stderr, @"Missing value for command line option %@, try --help!", argument);
 				break;
 			case GBParseFlagWrongGroup:
 				gbfprintln(stderr, @"Invalid option %@ for group %@!", argument, self.currentOptionsGroupName);


### PR DESCRIPTION
Since `argument` is an `NSString` this should use `%@` like the others.
